### PR TITLE
[FEAT] 유저 조회 API 연결

### DIFF
--- a/Twitter-iOS/Twitter-iOS.xcodeproj/project.pbxproj
+++ b/Twitter-iOS/Twitter-iOS.xcodeproj/project.pbxproj
@@ -83,6 +83,12 @@
 		4DC622EC2834C6F700186517 /* WritingViewController+Extesion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC622EB2834C6F700186517 /* WritingViewController+Extesion.swift */; };
 		4DC622EE2834DA5300186517 /* MyPhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC622ED2834DA5300186517 /* MyPhoto.swift */; };
 		4DE1C5FC284200B800B68602 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE1C5FB284200B800B68602 /* Writer.swift */; };
+		B58AC0C1284611D000AD88D3 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AC0C0284611D000AD88D3 /* User.swift */; };
+		B58AC0C32846142C00AD88D3 /* UserRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AC0C22846142C00AD88D3 /* UserRouter.swift */; };
+		B58AC0C5284616F500AD88D3 /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AC0C4284616F500AD88D3 /* UserService.swift */; };
+		B58AC0C7284618AA00AD88D3 /* Twit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AC0C6284618AA00AD88D3 /* Twit.swift */; };
+		B58AC0C928461A7500AD88D3 /* Like.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AC0C828461A7500AD88D3 /* Like.swift */; };
+		B58AC0CB284624E200AD88D3 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AC0CA284624E200AD88D3 /* String+Extension.swift */; };
 		B5939ACA2834F95100A769BF /* TweetTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5939AC82834F95100A769BF /* TweetTableViewCell.swift */; };
 		B5939ACB2834F95100A769BF /* TweetTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5939AC92834F95100A769BF /* TweetTableViewCell.xib */; };
 		B5D95D462835329800AA3C1F /* TweetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D95D452835329800AA3C1F /* TweetModel.swift */; };
@@ -169,6 +175,12 @@
 		4DC622EB2834C6F700186517 /* WritingViewController+Extesion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WritingViewController+Extesion.swift"; sourceTree = "<group>"; };
 		4DC622ED2834DA5300186517 /* MyPhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPhoto.swift; sourceTree = "<group>"; };
 		4DE1C5FB284200B800B68602 /* Writer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
+		B58AC0C0284611D000AD88D3 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		B58AC0C22846142C00AD88D3 /* UserRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRouter.swift; sourceTree = "<group>"; };
+		B58AC0C4284616F500AD88D3 /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
+		B58AC0C6284618AA00AD88D3 /* Twit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Twit.swift; sourceTree = "<group>"; };
+		B58AC0C828461A7500AD88D3 /* Like.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Like.swift; sourceTree = "<group>"; };
+		B58AC0CA284624E200AD88D3 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		B5939AC82834F95100A769BF /* TweetTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TweetTableViewCell.swift; path = "Twitter-iOS/Screens/Profile/Minjae/StoryBoard/TweetTableViewCell.swift"; sourceTree = SOURCE_ROOT; };
 		B5939AC92834F95100A769BF /* TweetTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = TweetTableViewCell.xib; path = "Twitter-iOS/Screens/Profile/Minjae/Xib/TweetTableViewCell.xib"; sourceTree = SOURCE_ROOT; };
 		B5D95D452835329800AA3C1F /* TweetModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetModel.swift; sourceTree = "<group>"; };
@@ -276,6 +288,9 @@
 				4D153CC82838B1E20072B731 /* GeneralResponse.swift */,
 				4D39BF6E283FCF1C0097A6EF /* Auth.swift */,
 				4DE1C5FB284200B800B68602 /* Writer.swift */,
+				B58AC0C0284611D000AD88D3 /* User.swift */,
+				B58AC0C6284618AA00AD88D3 /* Twit.swift */,
+				B58AC0C828461A7500AD88D3 /* Like.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -285,6 +300,7 @@
 			children = (
 				4D39BF70283FCF430097A6EF /* AuthRouter.swift */,
 				4D85A8612841FC3D00074D78 /* TwitPostRouter.swift */,
+				B58AC0C22846142C00AD88D3 /* UserRouter.swift */,
 			);
 			name = Router;
 			sourceTree = "<group>";
@@ -294,6 +310,7 @@
 			children = (
 				4D39BF72283FCF5E0097A6EF /* AuthService.swift */,
 				4D85A8632841FC4700074D78 /* TwitPostService.swift */,
+				B58AC0C4284616F500AD88D3 /* UserService.swift */,
 			);
 			name = Service;
 			sourceTree = "<group>";
@@ -421,6 +438,7 @@
 				4D32E25A28328A6700A3DD31 /* UITableView+Extension.swift */,
 				4D32E25C28328A7600A3DD31 /* UICollectionView+Extension.swift */,
 				4DC622E128348F2800186517 /* UIStackView+Extension.swift */,
+				B58AC0CA284624E200AD88D3 /* String+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -864,11 +882,13 @@
 				B5DEFEA528349CBB00D64C5E /* FavoriteViewController.swift in Sources */,
 				4D32E25D28328A7600A3DD31 /* UICollectionView+Extension.swift in Sources */,
 				4D153CC72838A01B0072B731 /* BaseService.swift in Sources */,
+				B58AC0C1284611D000AD88D3 /* User.swift in Sources */,
 				1A41E4622835D2E3006073D5 /* HomeTabViewController.swift in Sources */,
 				B5DEFEA328349CA700D64C5E /* MediaViewController.swift in Sources */,
 				1A166BFB283F460B003AC3F7 /* ProfileTableViewCell.swift in Sources */,
 				1A41E4622835D2E3006073D5 /* HomeTabViewController.swift in Sources */,
 				4D32E251283287D100A3DD31 /* UITextField+Extension.swift in Sources */,
+				B58AC0C7284618AA00AD88D3 /* Twit.swift in Sources */,
 				1A41E4642835D2F4006073D5 /* SecondTabViewController.swift in Sources */,
 				1A166C03283F66FB003AC3F7 /* TabmanTableViewCell.swift in Sources */,
 				4D32E2492832852A00A3DD31 /* UILabel+Extension.swift in Sources */,
@@ -896,9 +916,11 @@
 				4DC622E228348F2800186517 /* UIStackView+Extension.swift in Sources */,
 				1A41E47228360504006073D5 /* TwitterRetwittTableViewCell.swift in Sources */,
 				4D32E2452832832600A3DD31 /* ImageLiteral.swift in Sources */,
+				B58AC0C928461A7500AD88D3 /* Like.swift in Sources */,
 				1A41E4602835D1BE006073D5 /* TabManViewController.swift in Sources */,
 				4D32E223283118CF00A3DD31 /* SuYeonWritingViewController.swift in Sources */,
 				4D32E1E4283108CC00A3DD31 /* SceneDelegate.swift in Sources */,
+				B58AC0C5284616F500AD88D3 /* UserService.swift in Sources */,
 				4DC622EA2834C4E800186517 /* ImageCollectionViewCell.swift in Sources */,
 				4D153CC32838A0010072B731 /* NetworkResult.swift in Sources */,
 				4DC622E42834BB9100186517 /* CommentPermissionView.swift in Sources */,
@@ -912,7 +934,9 @@
 				4DC622E62834BE3D00186517 /* AlbumCollectionView.swift in Sources */,
 				4DE1C5FC284200B800B68602 /* Writer.swift in Sources */,
 				4D32E24128327B6D00A3DD31 /* UIColor+Extension.swift in Sources */,
+				B58AC0C32846142C00AD88D3 /* UserRouter.swift in Sources */,
 				4D39BF71283FCF430097A6EF /* AuthRouter.swift in Sources */,
+				B58AC0CB284624E200AD88D3 /* String+Extension.swift in Sources */,
 				B5DEFE9F28349C7C00D64C5E /* TweetViewController.swift in Sources */,
 				4D39BF73283FCF5E0097A6EF /* AuthService.swift in Sources */,
 			);

--- a/Twitter-iOS/Twitter-iOS/Global/Extension/String+Extension.swift
+++ b/Twitter-iOS/Twitter-iOS/Global/Extension/String+Extension.swift
@@ -1,0 +1,23 @@
+//
+//  String+.swift
+//  Twitter-iOS
+//
+//  Created by 김민재 on 2022/05/31.
+//
+
+import Foundation
+
+
+extension String {
+    func toDate() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+        dateFormatter.timeZone = TimeZone(identifier: "UTC")
+        
+        if let date = dateFormatter.date(from: self) {
+            return date
+        } else {
+            return nil
+        }
+    }
+}

--- a/Twitter-iOS/Twitter-iOS/Like.swift
+++ b/Twitter-iOS/Twitter-iOS/Like.swift
@@ -1,0 +1,13 @@
+//
+//  Like.swift
+//  Twitter-iOS
+//
+//  Created by 김민재 on 2022/05/31.
+//
+
+import Foundation
+
+struct Like: Codable {
+    let likeCount: Int
+    let isLike: Bool
+}

--- a/Twitter-iOS/Twitter-iOS/Screens/Profile/Minjae/StoryBoard/Profile.storyboard
+++ b/Twitter-iOS/Twitter-iOS/Screens/Profile/Minjae/StoryBoard/Profile.storyboard
@@ -59,14 +59,14 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Xx-gX-49O" userLabel="ProfileInfoView">
                                                 <rect key="frame" x="16" y="179" width="398" height="116"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="먀막" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AIy-X9-Jy5">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="마마" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AIy-X9-Jy5">
                                                         <rect key="frame" x="0.0" y="0.0" width="38.5" height="26"/>
                                                         <color key="tintColor" name="twitter_white"/>
                                                         <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="22"/>
                                                         <color key="textColor" name="twitter_white"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@hoho_0518" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qes-Kk-D23">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@hoho_0522" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qes-Kk-D23">
                                                         <rect key="frame" x="0.0" y="30" width="82" height="16.5"/>
                                                         <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="14"/>
                                                         <color key="textColor" name="twitter_gray50"/>
@@ -90,7 +90,7 @@
                                                             </label>
                                                         </subviews>
                                                     </stackView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="디자인/일상/인사이트/틈새기록/구독계" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nKl-lj-5P8">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="디자인/일상/인사이트/기록기록/구독계" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nKl-lj-5P8">
                                                         <rect key="frame" x="0.0" y="54.5" width="217" height="16.5"/>
                                                         <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="14"/>
                                                         <color key="textColor" name="twitter_gray10"/>
@@ -286,7 +286,11 @@
                         <outlet property="barViewWidth" destination="6eM-1H-p4T" id="zHP-4s-JGN"/>
                         <outlet property="containerView" destination="4dk-CO-bTe" id="Oxz-Jj-XYW"/>
                         <outlet property="containerViewHeight" destination="5cX-HP-TZC" id="nMn-dS-clQ"/>
+                        <outlet property="createdAtLabel" destination="kXh-3O-ulT" id="Ioc-Gh-E5x"/>
+                        <outlet property="introductionLabel" destination="nKl-lj-5P8" id="nx0-2O-bT7"/>
+                        <outlet property="profileIdLabel" destination="qes-Kk-D23" id="HoV-ng-YmD"/>
                         <outlet property="profileImageView" destination="Isd-Lq-Jnk" id="Fkf-DX-Wgk"/>
+                        <outlet property="profileNameLabel" destination="AIy-X9-Jy5" id="SEi-Zy-aUw"/>
                         <outlet property="scrollView" destination="cLp-u0-Uf9" id="9rj-wj-m67"/>
                         <outlet property="searchButton" destination="PWr-mg-xlA" id="lpK-wi-ZwZ"/>
                         <outlet property="tabStackView" destination="yYZ-FX-eRo" id="rSu-sl-Ph6"/>

--- a/Twitter-iOS/Twitter-iOS/Screens/Profile/Minjae/ViewController/ProfileViewController.swift
+++ b/Twitter-iOS/Twitter-iOS/Screens/Profile/Minjae/ViewController/ProfileViewController.swift
@@ -8,18 +8,27 @@
 import UIKit
 
 class ProfileViewController: UIViewController, UITableViewDelegate {
-
+    
+    // MARK: UI
     @IBOutlet weak var backArrow: UIButton!
     @IBOutlet weak var searchButton: UIButton!
     @IBOutlet weak var profileImageView: UIImageView!
+    @IBOutlet weak var profileNameLabel: UILabel!
+    @IBOutlet weak var profileIdLabel: UILabel!
+    @IBOutlet weak var introductionLabel: UILabel!
+    @IBOutlet weak var createdAtLabel: UILabel!
     
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var tabStackView: UIStackView!
     @IBOutlet weak var barView: UIView!
     @IBOutlet weak var barBackgroundView: UIView!
+    
+    // MARK: Passing Data
+    private var userKeyId = ""
+    
+    // MARK: Constraints
     @IBOutlet weak var barViewLeading: NSLayoutConstraint!
     @IBOutlet weak var barViewWidth: NSLayoutConstraint!
-    
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var containerViewHeight: NSLayoutConstraint!
     
@@ -38,8 +47,8 @@ class ProfileViewController: UIViewController, UITableViewDelegate {
     private var currentIdx = 0
     private var btnTapped = false
     
+    // MARK: Floating Button
     private let floatingButton = UIButton()
-    
     private func setFloatingButton() {
         floatingButton.frame = CGRect(x: self.view.frame.size.width - 112, y: UIScreen.main.bounds.height - 160, width: 56, height: 56)
         floatingButton.setImage(ImageLiteral.Writing.iconBigPlus, for: .normal)
@@ -53,15 +62,22 @@ class ProfileViewController: UIViewController, UITableViewDelegate {
         self.present(writingVC, animated: true)
     }
     
+    // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setProfileUI()
         setFloatingButton()
         setPageVC()
-        
+        getUserInfo()
         scrollView.delegate = self
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+    }
+    
+    // MARK: Custom Function
     private func setProfileUI() {
         makeImageCircle(profileImageView)
         makeButtonCircle(backArrow)
@@ -245,5 +261,38 @@ extension UIPageViewController {
     var scrollView: UIScrollView? {
 
         return view.subviews.filter { $0 is UIScrollView }.first as? UIScrollView
+    }
+}
+
+
+extension ProfileViewController {
+    private func getUserInfo() {
+
+        UserService.shared.getUserInfo { result in
+            switch result {
+            case .success(let data):
+                guard let data = data as? UserResponse else { return }
+                self.userKeyId = data.id
+                self.profileNameLabel.text = data.userName
+                self.profileIdLabel.text = data.userId
+                self.introductionLabel.text = data.introduce
+                
+                if let date = data.createdAt.toDate() {
+                    let calendarDate = Calendar.current.dateComponents([.year, .month], from: date)
+                    if let year = calendarDate.year, let month = calendarDate.month {
+                        self.createdAtLabel.text = "\(year)년 \(month)월에 가입함"
+                    }
+                }
+                
+            case .requestErr:
+                print("requestErr")
+            case .pathErr:
+                print("pathErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("networkFail")
+            }
+        }
     }
 }

--- a/Twitter-iOS/Twitter-iOS/Twit.swift
+++ b/Twitter-iOS/Twitter-iOS/Twit.swift
@@ -1,0 +1,17 @@
+//
+//  Twit.swift
+//  Twitter-iOS
+//
+//  Created by 김민재 on 2022/05/31.
+//
+
+import Foundation
+
+struct Twit: Codable {
+    let id: String
+    let content: String
+    let writer: Writer
+    let likeCount: Int
+    let isLike: Bool
+    let isRetwit: Bool
+}

--- a/Twitter-iOS/Twitter-iOS/User.swift
+++ b/Twitter-iOS/Twitter-iOS/User.swift
@@ -1,0 +1,26 @@
+//
+//  User.swift
+//  Twitter-iOS
+//
+//  Created by 김민재 on 2022/05/31.
+//
+
+import Foundation
+
+struct UserResponse: Codable {
+    let id: String
+    let userName: String
+    let userId: String
+    let introduce: String
+    let createdAt: String
+    let updatedAt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "_id"
+        case userName
+        case userId
+        case introduce
+        case createdAt
+        case updatedAt
+    }
+}

--- a/Twitter-iOS/Twitter-iOS/UserRouter.swift
+++ b/Twitter-iOS/Twitter-iOS/UserRouter.swift
@@ -1,0 +1,81 @@
+//
+//  UserRouter.swift
+//  Twitter-iOS
+//
+//  Created by 김민재 on 2022/05/31.
+//
+
+import Foundation
+import Alamofire
+
+enum UserRouter {
+    case getUserInfo
+    case getTwitList
+    case likeTwit(postId: Int)
+}
+
+extension UserRouter: BaseRouter {
+    
+    var path: String {
+        switch self {
+        case .getUserInfo:
+            return "/user"
+        case .getTwitList:
+            return "/twit"
+        case .likeTwit(let postId):
+            return "/like/\(postId)"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .getUserInfo, .getTwitList:
+            return .get
+        case .likeTwit:
+            return .post
+        }
+    }
+
+    var header: HeaderType {
+        switch self {
+        case .getUserInfo, .getTwitList, .likeTwit:
+            return .auth
+        }
+    }
+    
+    var parameters: RequestParams {
+        switch self {
+        case .getUserInfo, .getTwitList, .likeTwit:
+            return .requestPlain
+        }
+    }
+    
+//    var multipart: MultipartFormData {
+//        switch self {
+//        case .upload(let image):
+//            let multiPart = MultipartFormData()
+//
+//            let images = image
+//
+//            let contentStr = "안녕하세요"
+//            let userNameStr = "안현주친구"
+//            let profileURL = "https://thesopt.s3.ap-northeast-2.amazonaws.com/sample-profile-picture.png"
+//
+//            let content = contentStr.data(using: .utf8) ?? Data()
+//            let userprofile = profileURL.data(using: .utf8) ?? Data()
+//            let userName = userNameStr.data(using: .utf8) ?? Data()
+//            let imageData = images.pngData() ?? Data()
+//
+//            multiPart.append(content, withName: "content")
+//            multiPart.append(userName, withName: "userName")
+//            multiPart.append(userprofile, withName: "userProfileImage")
+//            multiPart.append(imageData, withName: "image", fileName: "profileImage.png", mimeType: "image/png")
+//
+//            return multiPart
+//
+//        default: return MultipartFormData()
+//        }
+//    }
+
+    
+}

--- a/Twitter-iOS/Twitter-iOS/UserService.swift
+++ b/Twitter-iOS/Twitter-iOS/UserService.swift
@@ -1,0 +1,70 @@
+//
+//  UserService.swift
+//  Twitter-iOS
+//
+//  Created by 김민재 on 2022/05/31.
+//
+
+import Foundation
+import UIKit
+import Alamofire
+
+class UserService: BaseService {
+    static let shared = UserService()
+
+    private override init() { }
+
+    func getUserInfo(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        AFmanager.request(UserRouter.getUserInfo)
+            .validate(statusCode: 200...500)
+            .responseData { response in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let data = response.data else { return }
+                let networkResult = self.judgeStatus(by: statusCode, data, UserResponse.self)
+
+                completion(networkResult)
+
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
+    
+    func getTwitList(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        AFmanager.request(UserRouter.getTwitList)
+            .validate(statusCode: 200...500)
+            .responseData { response in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let data = response.data else { return }
+                let networkResult = self.judgeStatus(by: statusCode, data, Twit.self)
+
+                completion(networkResult)
+
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
+    
+    func likeTwit(postId: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        AFmanager.request(UserRouter.likeTwit(postId: postId))
+            .validate(statusCode: 200...500)
+            .responseData { response in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let data = response.data else { return }
+                let networkResult = self.judgeStatus(by: statusCode, data, Like.self)
+
+                completion(networkResult)
+
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈 를 적어주세요 -->
- closed: #25 

### ✨ 작업한 내용
- [x] 유저 정보 조회 API 연결

### 🌀 PR Point
수연이가 미리 예시로 올려둔 코드랑 구현해놓은 거 보고 따라서 했는데 이상하거나 개선할점 있으면 알려주라!!

### 🍰 참고사항
createdAt 타입이 명세서에는 Date로 나와있지만 String으로 선언해야 파싱이 가능함.
String extension에 String을 Date타입으로 바꿔놓는 걸 넣어놨으니 그걸 사용해서 파싱하면 원하는대로 할 수 있지만 원래 String으로 넘어오는게 맞는지 살짝 의문?

- 일단 서버분들한테 명세서 수정은 요청드릴 예정.

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
| 로그 너무 이쁘다 | <img width="796" alt="image" src="https://user-images.githubusercontent.com/60292150/171158351-c99dd3dd-8321-4899-82ef-12d41f4157d8.png"> |
| 서버에서 보내준 값대로 보여지는 프로필 | ![image](https://user-images.githubusercontent.com/60292150/171158569-8725c0f7-4120-4746-9338-61a4c804a1be.png) |
